### PR TITLE
feat: Add support for wildcard tensor dimensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ npm-debug.log
 mock-debug.txt
 *.vsix
 .DS_Store
+
+# 
+reference/

--- a/debugger/interpreter/dialects/tensor.py
+++ b/debugger/interpreter/dialects/tensor.py
@@ -6,11 +6,63 @@ Handles operations: extract, insert, splat, etc.
 """
 
 import z3
-from typing import Any, Optional, Tuple
+from typing import Any, Optional, Tuple, List, Union
 
 from .base import OperationHandler
 from ..operations import LoadOperation, StoreOperation, Operation
 from ..models import SymbolicState, MLIRFunction
+
+
+def parse_tensor_dimensions(tensor_type: str) -> List[str]:
+    """Parse tensor type string and return list of dimension strings.
+
+    Example: "tensor<?x?x10xi32>" -> ["?", "?", "10"]
+    Handles nested types by skipping inside <> pairs.
+    """
+    # Find outermost '<' and '>'
+    start = tensor_type.find("<")
+    end = tensor_type.rfind(">")
+    if start == -1 or end == -1:
+        raise ValueError(f"Invalid tensor type: {tensor_type}")
+    inner = tensor_type[start + 1 : end].strip()
+    # Parse dimensions while skipping nested <>
+    dimensions = []
+    current = []
+    depth = 0
+    for ch in inner:
+        if ch == "<":
+            depth += 1
+            current.append(ch)
+        elif ch == ">":
+            depth -= 1
+            current.append(ch)
+        elif ch == "x" and depth == 0:
+            dimensions.append("".join(current).strip())
+            current = []
+        else:
+            current.append(ch)
+    if current:
+        dimensions.append("".join(current).strip())
+    # The last token is element type, remove it
+    if dimensions:
+        dimensions.pop()
+    return dimensions
+
+
+def count_wildcards(dimensions: List[str]) -> int:
+    """Count '?' wildcard dimensions."""
+    return sum(1 for d in dimensions if d == "?")
+
+
+def get_dimension_sizes(dimensions: List[str]) -> List[Union[int, None]]:
+    """Convert dimension strings to int or None for wildcard."""
+    result = []
+    for d in dimensions:
+        if d == "?":
+            result.append(None)
+        else:
+            result.append(int(d))
+    return result
 
 
 class TensorExtractHandler(OperationHandler):
@@ -166,15 +218,167 @@ class TensorSplatHandler(OperationHandler):
         if not op.dest:
             raise ValueError("tensor.splat must have destination")
 
+        # Extract dynamic sizes if present
+        dynamic_sizes = op.attributes.get("dynamic_sizes", [])
+
+        # Parse tensor type dimensions
+        tensor_type = op.result_type or "tensor<?xi32>"
+        dim_strings = parse_tensor_dimensions(tensor_type)
+        wildcard_count = count_wildcards(dim_strings)
+        if len(dynamic_sizes) != wildcard_count:
+            raise ValueError(
+                f"tensor.splat: expected {wildcard_count} dynamic sizes for type {tensor_type}, "
+                f"got {len(dynamic_sizes)}"
+            )
+
+        # Build shape list
+        shape = []
+        dynamic_idx = 0
+        for dim_str in dim_strings:
+            if dim_str == "?":
+                # Get dynamic size expression
+                size_name = dynamic_sizes[dynamic_idx]
+                # Strip leading '%' if present
+                if size_name.startswith("%"):
+                    size_name = size_name[1:]
+                size_expr = state.get_expr(size_name)
+                if size_expr is None:
+                    # Create fresh symbolic expression for size
+                    size_expr = z3.FreshConst(
+                        z3.IntSort(), f"dim_{op.dest}_{dynamic_idx}"
+                    )
+                    state.set_value(size_name, size_expr, "index")
+                shape.append(size_expr)
+                dynamic_idx += 1
+            else:
+                shape.append(int(dim_str))
+
+        # Store tensor shape in state
+        state.set_tensor_shape(op.dest, shape)
+
         # Create a fresh symbolic tensor
         expr = z3.FreshConst(z3.IntSort(), f"tensor_{op.dest}")
-        state.set_memory(op.dest, expr, op.result_type or "tensor<?xi32>")
-        state.set_value(op.dest, expr, op.result_type or "tensor<?xi32>")
+        state.set_memory(op.dest, expr, tensor_type)
+        state.set_value(op.dest, expr, tensor_type)
 
     def _try_concrete_evaluation(
         self, op: Operation, state: SymbolicState, func: MLIRFunction
     ) -> Any:
         """Splat operations don't have simple concrete values."""
+        return None
+
+
+class TensorEmptyHandler(OperationHandler):
+    """Handler for tensor.empty operation."""
+
+    def execute_symbolic(
+        self, op: Operation, state: SymbolicState, func: MLIRFunction, interpreter=None
+    ) -> None:
+        """Execute tensor.empty symbolically."""
+        if not op.dest:
+            raise ValueError("tensor.empty must have destination")
+
+        # Extract dynamic sizes if present
+        dynamic_sizes = op.attributes.get("dynamic_sizes", [])
+
+        # Parse tensor type dimensions
+        tensor_type = op.result_type or "tensor<?xi32>"
+        dim_strings = parse_tensor_dimensions(tensor_type)
+        wildcard_count = count_wildcards(dim_strings)
+        if len(dynamic_sizes) != wildcard_count:
+            raise ValueError(
+                f"tensor.empty: expected {wildcard_count} dynamic sizes for type {tensor_type}, "
+                f"got {len(dynamic_sizes)}"
+            )
+
+        # Build shape list
+        shape = []
+        dynamic_idx = 0
+        for dim_str in dim_strings:
+            if dim_str == "?":
+                size_name = dynamic_sizes[dynamic_idx]
+                if size_name.startswith("%"):
+                    size_name = size_name[1:]
+                size_expr = state.get_expr(size_name)
+                if size_expr is None:
+                    size_expr = z3.FreshConst(
+                        z3.IntSort(), f"dim_{op.dest}_{dynamic_idx}"
+                    )
+                    state.set_value(size_name, size_expr, "index")
+                shape.append(size_expr)
+                dynamic_idx += 1
+            else:
+                shape.append(int(dim_str))
+
+        # Store tensor shape in state
+        state.set_tensor_shape(op.dest, shape)
+
+        # Create a fresh symbolic tensor (contents unspecified)
+        expr = z3.FreshConst(z3.IntSort(), f"tensor_{op.dest}")
+        state.set_memory(op.dest, expr, tensor_type)
+        state.set_value(op.dest, expr, tensor_type)
+
+    def _try_concrete_evaluation(
+        self, op: Operation, state: SymbolicState, func: MLIRFunction
+    ) -> Any:
+        """empty operations don't have simple concrete values."""
+        return None
+
+
+class TensorGenerateHandler(OperationHandler):
+    """Handler for tensor.generate operation."""
+
+    def execute_symbolic(
+        self, op: Operation, state: SymbolicState, func: MLIRFunction, interpreter=None
+    ) -> None:
+        """Execute tensor.generate symbolically."""
+        if not op.dest:
+            raise ValueError("tensor.generate must have destination")
+
+        # Extract dynamic extents if present
+        dynamic_extents = op.attributes.get("dynamic_extents", [])
+
+        # Parse tensor type dimensions
+        tensor_type = op.result_type or "tensor<?xi32>"
+        dim_strings = parse_tensor_dimensions(tensor_type)
+        wildcard_count = count_wildcards(dim_strings)
+        if len(dynamic_extents) != wildcard_count:
+            raise ValueError(
+                f"tensor.generate: expected {wildcard_count} dynamic extents for type {tensor_type}, "
+                f"got {len(dynamic_extents)}"
+            )
+
+        # Build shape list
+        shape = []
+        dynamic_idx = 0
+        for dim_str in dim_strings:
+            if dim_str == "?":
+                size_name = dynamic_extents[dynamic_idx]
+                if size_name.startswith("%"):
+                    size_name = size_name[1:]
+                size_expr = state.get_expr(size_name)
+                if size_expr is None:
+                    size_expr = z3.FreshConst(
+                        z3.IntSort(), f"dim_{op.dest}_{dynamic_idx}"
+                    )
+                    state.set_value(size_name, size_expr, "index")
+                shape.append(size_expr)
+                dynamic_idx += 1
+            else:
+                shape.append(int(dim_str))
+
+        # Store tensor shape in state
+        state.set_tensor_shape(op.dest, shape)
+
+        # Create a fresh symbolic tensor (contents from region, ignored for now)
+        expr = z3.FreshConst(z3.IntSort(), f"tensor_{op.dest}")
+        state.set_memory(op.dest, expr, tensor_type)
+        state.set_value(op.dest, expr, tensor_type)
+
+    def _try_concrete_evaluation(
+        self, op: Operation, state: SymbolicState, func: MLIRFunction
+    ) -> Any:
+        """generate operations don't have simple concrete values."""
         return None
 
 
@@ -184,3 +388,5 @@ def register_handlers(registry) -> None:
     registry.register("tensor.extract", TensorExtractHandler())
     registry.register("tensor.insert", TensorInsertHandler())
     registry.register("tensor.splat", TensorSplatHandler())
+    registry.register("tensor.empty", TensorEmptyHandler())
+    registry.register("tensor.generate", TensorGenerateHandler())

--- a/debugger/interpreter/models.py
+++ b/debugger/interpreter/models.py
@@ -163,6 +163,19 @@ class SymbolicState:
     memory_model: MemoryModel = field(
         default_factory=MemrefMemoryModel
     )  # Unified memory model for symbolic/concrete storage
+    tensor_shapes: Dict[str, List[Union[int, z3.ExprRef]]] = field(
+        default_factory=dict
+    )  # Tensor name -> shape (list of dimension sizes)
+
+    def set_tensor_shape(
+        self, tensor: str, shape: List[Union[int, z3.ExprRef]]
+    ) -> None:
+        """Store shape of a tensor."""
+        self.tensor_shapes[tensor] = shape
+
+    def get_tensor_shape(self, tensor: str) -> Optional[List[Union[int, z3.ExprRef]]]:
+        """Retrieve shape of a tensor."""
+        return self.tensor_shapes.get(tensor)
 
     def fork(self) -> "SymbolicState":
         """Create a copy of this state."""
@@ -189,6 +202,7 @@ class SymbolicState:
             },
             memory_cells=memory_cells_copy,
             memory_model=forked_memory_model,
+            tensor_shapes=dict(self.tensor_shapes),
         )
 
     def add_path_condition(self, condition: z3.ExprRef) -> None:

--- a/debugger/interpreter/operations.py
+++ b/debugger/interpreter/operations.py
@@ -560,6 +560,7 @@ def operation_from_dict(op_dict: Dict[str, Any]) -> Operation:
         line=line,
         dest=dest,
         result_type=op_dict.get("type"),
+        attributes=op_dict.get("attributes", {}),
     )
 
 

--- a/debugger/interpreter/parser.py
+++ b/debugger/interpreter/parser.py
@@ -1839,7 +1839,12 @@ class MLIRParser:
             "op": op.__class__._opname_,
             "arg": self._ssa_use_to_string(op.arg),
             "type": self._type_to_string(op.type),
+            "attributes": {},
         }
+        if hasattr(op, "dynamic_sizes") and op.dynamic_sizes is not None:
+            result["attributes"]["dynamic_sizes"] = [
+                self._ssa_use_to_string(sz) for sz in op.dynamic_sizes
+            ]
         if op_node.result_list:
             result_item = op_node.result_list[0]
             if hasattr(result_item, "value") and hasattr(result_item.value, "value"):
@@ -1969,7 +1974,12 @@ class MLIRParser:
         result = {
             "op": op.__class__._opname_,
             "type": self._type_to_string(op.type),
+            "attributes": {},
         }
+        if hasattr(op, "dynamic_sizes") and op.dynamic_sizes is not None:
+            result["attributes"]["dynamic_sizes"] = [
+                self._ssa_use_to_string(sz) for sz in op.dynamic_sizes
+            ]
         if op_node.result_list:
             result_item = op_node.result_list[0]
             if hasattr(result_item, "value") and hasattr(result_item.value, "value"):
@@ -2033,7 +2043,20 @@ class MLIRParser:
         result = {
             "op": op.__class__._opname_,
             "type": self._type_to_string(op.type),
+            "attributes": {},
         }
+        if hasattr(op, "dynamic_extents") and op.dynamic_extents is not None:
+            result["attributes"]["dynamic_extents"] = [
+                self._ssa_use_to_string(ext) for ext in op.dynamic_extents
+            ]
+        if op.body and op.body.body:
+            # Parse region body operations
+            result["body"] = []
+            for block in op.body.body:
+                for body_op in block.body:
+                    op_dict = self._parse_operation(body_op)
+                    if op_dict:
+                        result["body"].append(op_dict)
         if op_node.result_list:
             result_item = op_node.result_list[0]
             if hasattr(result_item, "value") and hasattr(result_item.value, "value"):

--- a/debugger/parser/dialects/tensor.py
+++ b/debugger/parser/dialects/tensor.py
@@ -27,7 +27,11 @@ class ExtractOperation(DialectOp):
 class SplatOperation(DialectOp):
     arg: SsaUse
     type: Union[mast.VectorType, mast.TensorType]
-    _syntax_ = "tensor.splat {arg.ssa_use} : {type.type}"  # (vector_type | tensor_type)
+    dynamic_sizes: Optional[List[SsaUse]] = None
+    _syntax_ = [
+        "tensor.splat {arg.ssa_use} : {type.type}",
+        "tensor.splat {arg.ssa_use} [ {dynamic_sizes.ssa_use_list} ] : {type.type}",
+    ]
     _opname_ = "tensor.splat"
 
 
@@ -110,7 +114,11 @@ class DimOperation(DialectOp):
 @dataclass
 class EmptyOperation(DialectOp):
     type: mast.TensorType
-    _syntax_ = "tensor.empty : {type.tensor_type}"
+    dynamic_sizes: Optional[List[SsaUse]] = None
+    _syntax_ = [
+        "tensor.empty : {type.tensor_type}",
+        "tensor.empty ( {dynamic_sizes.ssa_use_list} ) : {type.tensor_type}",
+    ]
     _opname_ = "tensor.empty"
 
 
@@ -150,7 +158,12 @@ class FromElementsOperation(DialectOp):
 @dataclass
 class GenerateOperation(DialectOp):
     type: mast.TensorType
-    _syntax_ = "tensor.generate {type.tensor_type}"
+    body: mast.Region
+    dynamic_extents: Optional[List[SsaUse]] = None
+    _syntax_ = [
+        "tensor.generate {body.region} : {type.tensor_type}",
+        "tensor.generate {dynamic_extents.ssa_use_list} {body.region} : {type.tensor_type}",
+    ]
     _opname_ = "tensor.generate"
 
 


### PR DESCRIPTION
- Support MLIR-compliant wildcard tensor dimensions (e.g., tensor<?x?x10xi32>)
- Add dynamic size arguments to tensor.empty, tensor.splat, tensor.generate
- Implement dimension validation: dynamic sizes count must match wildcard count
- Add tensor shape tracking in symbolic state for debugger display
- Maintain backward compatibility with static tensor operations
