### PR TITLE
feat: implement tensor/memref memory model separation

### DIFF
--- a/debugger/interpreter/dialects/tensor.py
+++ b/debugger/interpreter/dialects/tensor.py
@@ -9,7 +9,7 @@ import z3
 from typing import Any, Optional, Tuple, List, Union
 
 from .base import OperationHandler
-from ..operations import LoadOperation, StoreOperation, Operation
+from ..operations import LoadOperation, StoreOperation, Operation, UnaryOperation
 from ..models import SymbolicState, MLIRFunction
 
 
@@ -65,6 +65,29 @@ def get_dimension_sizes(dimensions: List[str]) -> List[Union[int, None]]:
     return result
 
 
+def extract_element_type(tensor_type: str) -> str:
+    """Extract element type from tensor type string."""
+    # Find outermost '<' and '>'
+    start = tensor_type.find("<")
+    end = tensor_type.rfind(">")
+    if start == -1 or end == -1:
+        return "i32"  # fallback
+    inner = tensor_type[start + 1 : end].strip()
+    # Find last 'x' not inside nested <>
+    depth = 0
+    last_x_pos = -1
+    for i, ch in enumerate(inner):
+        if ch == "<":
+            depth += 1
+        elif ch == ">":
+            depth -= 1
+        elif ch == "x" and depth == 0:
+            last_x_pos = i
+    if last_x_pos == -1:
+        return inner.strip()
+    return inner[last_x_pos + 1 :].strip()
+
+
 class TensorExtractHandler(OperationHandler):
     """Handler for tensor.extract operation."""
 
@@ -81,37 +104,40 @@ class TensorExtractHandler(OperationHandler):
 
         tensor = op.memref
         indices = op.indices
+        dtype = op.result_type or "i32"
 
-        # Try to get concrete indices
-        concrete_indices = self._get_concrete_indices(indices, state)
+        # Convert index names to values (int or z3 expression)
+        index_values = []
+        for idx_name in indices:
+            # Try to get concrete value first
+            concrete = state.get_concrete_value(idx_name)
+            if concrete is not None and isinstance(concrete, int):
+                index_values.append(concrete)
+                continue
+            # Try to parse as integer constant
+            try:
+                val = int(idx_name)
+                index_values.append(val)
+                continue
+            except (ValueError, TypeError):
+                pass
+            # Get symbolic expression
+            expr = state.get_expr(idx_name)
+            if expr is None:
+                # Create fresh symbolic index
+                expr = z3.FreshConst(z3.IntSort(), f"index_{idx_name}")
+                state.set_value(idx_name, expr, "index")
+            index_values.append(expr)
 
-        if concrete_indices is not None:
-            # Multi-cell access with concrete indices
-            tensor_value = state.get_memory_cell(tensor, concrete_indices)
-            if tensor_value is None:
-                # Uninitialized cell: create fresh symbolic value
-                expr = z3.FreshConst(z3.IntSort(), f"tensor_{tensor}{concrete_indices}")
-                state.set_memory_cell(
-                    tensor, concrete_indices, expr, op.result_type or "i32"
-                )
-                tensor_value = state.get_memory_cell(tensor, concrete_indices)
-            assert tensor_value is not None
-            assert tensor_value.expr is not None
-            state.set_value(op.dest, tensor_value.expr, op.result_type or "i32")
-            # Try to get concrete value from tensor cell
-            concrete_val = state.get_memory_cell_concrete(tensor, concrete_indices)
-            if concrete_val is not None:
-                state.set_concrete_value(op.dest, concrete_val)
-        else:
-            # Symbolic indices or no indices: fall back to single-cell model
-            tensor_value = state.get_memory(tensor)
-            if tensor_value is None:
-                expr = z3.FreshConst(z3.IntSort(), f"tensor_{tensor}")
-                state.set_memory(tensor, expr, op.result_type or "i32")
-                tensor_value = state.get_memory(tensor)
-            assert tensor_value is not None
-            assert tensor_value.expr is not None
-            state.set_value(op.dest, tensor_value.expr, op.result_type or "i32")
+        # Load from tensor memory model
+        expr = state.tensor_memory_model.load(tensor, index_values, dtype)
+        if op.dest:
+            state.set_value(op.dest, expr, dtype)
+
+        # Try to get concrete value
+        concrete_val = self._try_concrete_evaluation(op, state, func)
+        if concrete_val is not None and op.dest:
+            state.set_concrete_value(op.dest, concrete_val)
 
     def _try_concrete_evaluation(
         self, op: LoadOperation, state: SymbolicState, func: MLIRFunction
@@ -122,15 +148,13 @@ class TensorExtractHandler(OperationHandler):
 
         concrete_indices = self._get_concrete_indices(indices, state)
         if concrete_indices is not None:
-            concrete_val = state.get_memory_cell_concrete(tensor, concrete_indices)
+            concrete_val = state.tensor_memory_model.get_concrete_value(
+                tensor, list(concrete_indices)
+            )
             if concrete_val is not None:
                 return concrete_val
 
-        # Check single-cell memory model
-        tensor_concrete = state.get_concrete_value(tensor)
-        if tensor_concrete is not None:
-            return tensor_concrete
-
+        # No concrete value found
         return None
 
     def _get_concrete_indices(
@@ -156,38 +180,104 @@ class TensorInsertHandler(OperationHandler):
         func: MLIRFunction,
         interpreter=None,
     ) -> None:
-        """Execute tensor.insert symbolically."""
+        """Execute tensor.insert symbolically using copy-on-write semantics."""
+
         if not isinstance(op, StoreOperation):
             raise TypeError(f"Expected StoreOperation, got {type(op)}")
 
-        tensor = op.memref
+        src_tensor = op.memref
         value = op.value
         indices = op.indices
+
+        # Destination tensor (result of insert)
+        if not op.dest:
+            raise ValueError("tensor.insert must have destination tensor")
+        dst_tensor = op.dest
 
         # Get value expression
         value_expr = state.get_expr(value)
         if value_expr is None:
             raise ValueError(f"Cannot get expression for value: {value}")
 
-        # Try to get concrete indices
-        concrete_indices = self._get_concrete_indices(indices, state)
+        # Get concrete value if available
+        concrete_val = state.get_concrete_value(value)
 
-        if concrete_indices is not None:
-            # Multi-cell insert with concrete indices
-            state.set_memory_cell(
-                tensor, concrete_indices, value_expr, op.result_type or "i32"
+        # Parse indices (convert to int or z3 expression)
+        index_values = []
+        concrete_indices = []
+        all_concrete = True
+        for idx_name in indices:
+            # Try to get concrete value first
+            concrete = state.get_concrete_value(idx_name)
+            if concrete is not None and isinstance(concrete, int):
+                index_values.append(concrete)
+                if concrete_indices is not None:
+                    concrete_indices.append(concrete)
+                continue
+            # Try to parse as integer constant
+            try:
+                val = int(idx_name)
+                index_values.append(val)
+                if concrete_indices is not None:
+                    concrete_indices.append(val)
+                continue
+            except (ValueError, TypeError):
+                pass
+            # Get symbolic expression
+            expr = state.get_expr(idx_name)
+            if expr is None:
+                # Create fresh symbolic index
+                expr = z3.FreshConst(z3.IntSort(), f"index_{idx_name}")
+                state.set_value(idx_name, expr, "index")
+            index_values.append(expr)
+            all_concrete = False
+            concrete_indices = None  # Can't use concrete indices if any symbolic
+
+        # Extract element type from tensor type
+        tensor_type = op.result_type or "tensor<?xi32>"
+        element_type = self._extract_element_type(tensor_type)
+
+        # Debug
+        # Copy source tensor to destination (copy-on-write)
+        state.tensor_memory_model.copy_tensor(src_tensor, dst_tensor)
+
+        # Store value at indices in destination tensor
+        state.tensor_memory_model.store(
+            dst_tensor, index_values, value_expr, element_type
+        )
+
+        # Store concrete value if available and indices are concrete
+        if concrete_val is not None and all_concrete and concrete_indices is not None:
+            state.tensor_memory_model.set_concrete_value(
+                dst_tensor, concrete_indices, concrete_val
             )
-            # Store concrete value if available
-            concrete_val = state.get_concrete_value(value)
-            if concrete_val is not None:
-                state.set_memory_cell_concrete(tensor, concrete_indices, concrete_val)
-        else:
-            # Symbolic indices or no indices: fall back to single-cell model
-            state.set_memory(tensor, value_expr, op.result_type or "i32")
-            # Store concrete value if available
-            concrete_val = state.get_concrete_value(value)
-            if concrete_val is not None:
-                state.set_concrete_value(tensor, concrete_val)
+
+        # Also set the destination value in state's value map (tensor as whole)
+        # For tensors, we can store a reference to the tensor memory
+        tensor_expr = z3.FreshConst(z3.IntSort(), f"tensor_{dst_tensor}")
+        state.set_value(dst_tensor, tensor_expr, tensor_type)
+
+    def _extract_element_type(self, tensor_type: str) -> str:
+        """Extract element type from tensor type string."""
+        # Find outermost '<' and '>'
+        start = tensor_type.find("<")
+        end = tensor_type.rfind(">")
+        if start == -1 or end == -1:
+            return "i32"  # fallback
+        inner = tensor_type[start + 1 : end].strip()
+        # Find last 'x' not inside nested <>
+        depth = 0
+        last_x_pos = -1
+        for i, ch in enumerate(inner):
+            if ch == "<":
+                depth += 1
+            elif ch == ">":
+                depth -= 1
+            elif ch == "x" and depth == 0:
+                last_x_pos = i
+        if last_x_pos == -1:
+            return inner.strip()
+        return inner[last_x_pos + 1 :].strip()
 
     def _try_concrete_evaluation(
         self, op: StoreOperation, state: SymbolicState, func: MLIRFunction
@@ -217,6 +307,30 @@ class TensorSplatHandler(OperationHandler):
         """Execute tensor.splat symbolically."""
         if not op.dest:
             raise ValueError("tensor.splat must have destination")
+
+        # Get value operand (splat value)
+        value_operand = None
+        if isinstance(op, UnaryOperation):
+            value_operand = op.operand
+        else:
+            # Fallback to attributes
+            value_operand = op.attributes.get("arg")
+            if value_operand is None:
+                # Try "value" attribute
+                value_operand = op.attributes.get("value")
+
+        if value_operand is None:
+            raise ValueError("tensor.splat missing value operand")
+
+        # Get value expression
+        value_expr = state.get_expr(value_operand)
+        if value_expr is None:
+            # Create fresh symbolic value
+            value_expr = z3.FreshConst(z3.IntSort(), f"val_{value_operand}")
+            state.set_value(value_operand, value_expr, "i32")
+
+        # Get concrete value if available
+        concrete_val = state.get_concrete_value(value_operand)
 
         # Extract dynamic sizes if present
         dynamic_sizes = op.attributes.get("dynamic_sizes", [])
@@ -253,13 +367,23 @@ class TensorSplatHandler(OperationHandler):
             else:
                 shape.append(int(dim_str))
 
-        # Store tensor shape in state
+        # Store tensor shape in tensor memory model
         state.set_tensor_shape(op.dest, shape)
+        # Set dtype
+        element_type = extract_element_type(tensor_type)
+        state.tensor_memory_model.dtypes[op.dest] = element_type
 
-        # Create a fresh symbolic tensor
+        # Set splat value in tensor memory model
+        state.tensor_memory_model.set_splat_value(
+            tensor=op.dest,
+            symbolic_expr=value_expr,
+            concrete_value=concrete_val,
+        )
+
+        # Create a fresh symbolic tensor reference (for value map)
         expr = z3.FreshConst(z3.IntSort(), f"tensor_{op.dest}")
-        state.set_memory(op.dest, expr, tensor_type)
         state.set_value(op.dest, expr, tensor_type)
+        # Do NOT store in legacy memory model
 
     def _try_concrete_evaluation(
         self, op: Operation, state: SymbolicState, func: MLIRFunction
@@ -310,13 +434,13 @@ class TensorEmptyHandler(OperationHandler):
             else:
                 shape.append(int(dim_str))
 
-        # Store tensor shape in state
+        # Store tensor shape in tensor memory model
         state.set_tensor_shape(op.dest, shape)
 
-        # Create a fresh symbolic tensor (contents unspecified)
+        # Create a fresh symbolic tensor reference (for value map)
         expr = z3.FreshConst(z3.IntSort(), f"tensor_{op.dest}")
-        state.set_memory(op.dest, expr, tensor_type)
         state.set_value(op.dest, expr, tensor_type)
+        # Do NOT store in legacy memory model
 
     def _try_concrete_evaluation(
         self, op: Operation, state: SymbolicState, func: MLIRFunction
@@ -367,13 +491,13 @@ class TensorGenerateHandler(OperationHandler):
             else:
                 shape.append(int(dim_str))
 
-        # Store tensor shape in state
+        # Store tensor shape in tensor memory model
         state.set_tensor_shape(op.dest, shape)
 
-        # Create a fresh symbolic tensor (contents from region, ignored for now)
+        # Create a fresh symbolic tensor reference (for value map)
         expr = z3.FreshConst(z3.IntSort(), f"tensor_{op.dest}")
-        state.set_memory(op.dest, expr, tensor_type)
         state.set_value(op.dest, expr, tensor_type)
+        # Do NOT store in legacy memory model
 
     def _try_concrete_evaluation(
         self, op: Operation, state: SymbolicState, func: MLIRFunction

--- a/debugger/interpreter/memory/tensor.py
+++ b/debugger/interpreter/memory/tensor.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""
+Tensor memory model implementation.
+
+Handles multi-dimensional tensor storage with immutable value semantics.
+Tensors are immutable values; tensor.insert creates a new tensor copy.
+"""
+
+from typing import Dict, List, Tuple, Optional, Union, Any
+from dataclasses import dataclass, field
+import z3
+
+from .base import MemoryModel
+
+
+class TensorMemoryModel(MemoryModel):
+    """Memory model for tensor operations with immutable value semantics."""
+
+    def __init__(self):
+        # Maps tensor name -> shape list (dimension sizes, can be int or symbolic)
+        self.shapes: Dict[str, List[Union[int, z3.ExprRef]]] = {}
+        # Maps tensor name -> dtype string
+        self.dtypes: Dict[str, str] = {}
+        # Maps (tensor_name, indices_tuple) -> symbolic expression
+        self.storage: Dict[Tuple[str, Tuple[int, ...]], z3.ExprRef] = {}
+        # Maps (tensor_name, indices_tuple) -> concrete Python values
+        self.concrete_storage: Dict[Tuple[str, Tuple[int, ...]], Any] = {}
+        # Maps tensor name -> splat value (symbolic) for tensors created via splat
+        self.splat_values: Dict[str, Optional[z3.ExprRef]] = {}
+        # Maps tensor name -> concrete splat value
+        self.splat_concrete: Dict[str, Any] = {}
+
+    def allocate(self, name: str, shape: Tuple[int, ...], dtype: str) -> None:
+        """Allocate a new tensor with given shape and dtype.
+
+        For tensors, shape dimensions are integers (dynamic dimensions as -1).
+        The actual symbolic dimension expressions are stored separately in self.shapes.
+        """
+        # Convert tuple to list for shape storage (will be updated with symbolic dims later)
+        self.shapes[name] = list(shape)
+        self.dtypes[name] = dtype
+        # No need to initialize storage - cells will be created lazily on first store
+
+    def load(
+        self,
+        memref: str,
+        indices: List[Union[int, z3.ExprRef]],
+        dtype: str,
+    ) -> z3.ExprRef:
+        """Load value from tensor at given indices.
+
+        If indices are symbolic, returns a fresh symbolic value representing
+        the access result (since we can't know which concrete cell is accessed).
+        If tensor has a splat value, returns that value for any indices.
+        """
+        # Check if tensor has a splat value
+        splat_expr = self.splat_values.get(memref)
+        if splat_expr is not None:
+            return splat_expr
+
+        # Check if all indices are concrete
+        concrete_key = self._indices_to_key(indices)
+
+        if concrete_key is not None:
+            # Concrete indices - look up in storage
+            storage_key = (memref, concrete_key)
+            if storage_key in self.storage:
+                return self.storage[storage_key]
+
+            # Cell not initialized - create fresh symbolic value
+            expr = z3.FreshConst(
+                z3.IntSort(),
+                f"tensor_{memref}_{'_'.join(str(i) for i in concrete_key)}",
+            )
+            self.storage[storage_key] = expr
+            return expr
+        else:
+            # Symbolic indices - create fresh symbolic value for the access
+            expr = z3.FreshConst(
+                z3.IntSort(),
+                f"tensor_{memref}_symbolic_access",
+            )
+            return expr
+
+    def store(
+        self,
+        memref: str,
+        indices: List[Union[int, z3.ExprRef]],
+        value: z3.ExprRef,
+        dtype: str,
+    ) -> None:
+        """Store value to tensor at given indices.
+
+        For tensors, store is allowed only once per cell (immutable after creation).
+        If a cell already has a value, this raises ValueError.
+        """
+        # Check if all indices are concrete
+        concrete_key = self._indices_to_key(indices)
+
+        if concrete_key is not None:
+            # Concrete indices - store in storage
+            storage_key = (memref, concrete_key)
+            if storage_key in self.storage:
+                # Cell already has a value - tensors are immutable after creation
+                # But for copy-on-write, we might be storing to a newly copied tensor
+                # Allow overwriting for now (will be used by copy_tensor)
+                pass
+            self.storage[storage_key] = value
+        else:
+            # Symbolic indices - store at a special key
+            storage_key = (memref, (-1,))  # Sentinel for symbolic store
+            self.storage[storage_key] = value
+
+    def reinterpret_cast(
+        self,
+        src: str,
+        dst: str,
+        offsets: List[Union[int, z3.ExprRef]],
+        sizes: List[Union[int, z3.ExprRef]],
+        strides: List[Union[int, z3.ExprRef]],
+    ) -> None:
+        """Tensors do not support views or reinterpret_cast.
+
+        Raises NotImplementedError as per MLIR semantics.
+        """
+        raise NotImplementedError("reinterpret_cast not supported for tensors")
+
+    def get_concrete_value(
+        self,
+        memref: str,
+        indices: List[int],
+    ) -> Optional[Any]:
+        """Get concrete value stored at concrete indices."""
+        indices_tuple = tuple(indices)
+        storage_key = (memref, indices_tuple)
+        return self.concrete_storage.get(storage_key)
+
+    def set_concrete_value(
+        self,
+        memref: str,
+        indices: List[int],
+        value: Any,
+    ) -> None:
+        """Set concrete value at concrete indices."""
+        indices_tuple = tuple(indices)
+        storage_key = (memref, indices_tuple)
+        self.concrete_storage[storage_key] = value
+
+    def fork(self) -> "TensorMemoryModel":
+        """Create a deep copy of the memory model for forking states."""
+        new_model = TensorMemoryModel()
+
+        # Copy primitive dicts
+        new_model.shapes = {
+            k: list(v) for k, v in self.shapes.items()
+        }  # shallow copy of list
+        new_model.dtypes = dict(self.dtypes)
+
+        # Deep copy storage (z3 expressions are immutable, can share references)
+        new_model.storage = dict(self.storage)
+
+        # Deep copy concrete storage
+        new_model.concrete_storage = dict(self.concrete_storage)
+
+        return new_model
+
+    def get_all_memory_entries(self) -> Dict[str, List[Dict[str, Any]]]:
+        """Get all tensor entries for debugging/DAP.
+
+        Returns:
+            Dictionary mapping tensor name to list of entries, each with
+            indices, symbolic expression, and concrete value if available.
+        """
+        entries = {}
+
+        # Collect from storage (symbolic values)
+        for (tensor, indices), expr in self.storage.items():
+            if tensor not in entries:
+                entries[tensor] = []
+
+            concrete = self.concrete_storage.get((tensor, indices))
+            entries[tensor].append(
+                {
+                    "indices": indices,
+                    "symbolic_expr": expr,
+                    "concrete_value": concrete,
+                }
+            )
+
+        # Also include tensors that are allocated but have no entries yet
+        for tensor in self.shapes:
+            if tensor not in entries:
+                entries[tensor] = []
+
+        return entries
+
+    def copy_tensor(self, src: str, dst: str) -> None:
+        """Create a copy of tensor src as a new tensor dst.
+
+        Copies shape, dtype, and all cell values (symbolic and concrete).
+        Used by tensor.insert to create new tensor with updated value.
+        """
+        if src not in self.shapes:
+            raise ValueError(f"Source tensor '{src}' not allocated")
+
+        # Copy shape and dtype
+        self.shapes[dst] = list(self.shapes[src])
+        # Use src dtype if present, otherwise default to "i32"
+        src_dtype = self.dtypes.get(src, "i32")
+        self.dtypes[dst] = src_dtype
+
+        # Copy all cell values
+        for (tensor, indices), expr in self.storage.items():
+            if tensor == src:
+                self.storage[(dst, indices)] = expr
+
+        # Copy concrete values
+        for (tensor, indices), value in self.concrete_storage.items():
+            if tensor == src:
+                self.concrete_storage[(dst, indices)] = value
+
+        # Copy splat values
+        if src in self.splat_values:
+            self.splat_values[dst] = self.splat_values[src]
+        if src in self.splat_concrete:
+            self.splat_concrete[dst] = self.splat_concrete[src]
+
+    def set_shape(self, tensor: str, shape: List[Union[int, z3.ExprRef]]) -> None:
+        """Set shape of a tensor (including symbolic dimensions)."""
+        self.shapes[tensor] = shape
+
+    def get_shape(self, tensor: str) -> Optional[List[Union[int, z3.ExprRef]]]:
+        """Get shape of a tensor."""
+        return self.shapes.get(tensor)
+
+    def set_splat_value(
+        self,
+        tensor: str,
+        symbolic_expr: Optional[z3.ExprRef] = None,
+        concrete_value: Any = None,
+    ) -> None:
+        """Set splat value for a tensor (uniform value across all cells)."""
+        self.splat_values[tensor] = symbolic_expr
+        if concrete_value is not None:
+            self.splat_concrete[tensor] = concrete_value
+
+    # Helper methods
+    def _indices_to_key(
+        self, indices: List[Union[int, z3.ExprRef]]
+    ) -> Optional[Tuple[int, ...]]:
+        """Convert indices to concrete tuple if all are concrete ints."""
+        concrete_indices = []
+        for idx in indices:
+            if isinstance(idx, int):
+                concrete_indices.append(idx)
+            else:
+                # Symbolic index
+                return None
+        return tuple(concrete_indices)

--- a/debugger/interpreter/models.py
+++ b/debugger/interpreter/models.py
@@ -9,6 +9,7 @@ import z3
 
 from .memory.base import MemoryModel
 from .memory.memref import MemrefMemoryModel
+from .memory.tensor import TensorMemoryModel
 
 
 @dataclass
@@ -162,20 +163,20 @@ class SymbolicState:
     )  # Multi-cell memory storage indexed by concrete indices (deprecated, use memory_model)
     memory_model: MemoryModel = field(
         default_factory=MemrefMemoryModel
-    )  # Unified memory model for symbolic/concrete storage
-    tensor_shapes: Dict[str, List[Union[int, z3.ExprRef]]] = field(
-        default_factory=dict
-    )  # Tensor name -> shape (list of dimension sizes)
+    )  # Memory model for memref operations
+    tensor_memory_model: TensorMemoryModel = field(
+        default_factory=TensorMemoryModel
+    )  # Memory model for tensor operations
 
     def set_tensor_shape(
         self, tensor: str, shape: List[Union[int, z3.ExprRef]]
     ) -> None:
         """Store shape of a tensor."""
-        self.tensor_shapes[tensor] = shape
+        self.tensor_memory_model.set_shape(tensor, shape)
 
     def get_tensor_shape(self, tensor: str) -> Optional[List[Union[int, z3.ExprRef]]]:
         """Retrieve shape of a tensor."""
-        return self.tensor_shapes.get(tensor)
+        return self.tensor_memory_model.get_shape(tensor)
 
     def fork(self) -> "SymbolicState":
         """Create a copy of this state."""
@@ -187,8 +188,9 @@ class SymbolicState:
                 for idx, val in cells.items()
             }
 
-        # Fork memory model
+        # Fork memory models
         forked_memory_model = self.memory_model.fork()
+        forked_tensor_memory_model = self.tensor_memory_model.fork()
 
         return SymbolicState(
             pc=self.pc,
@@ -202,7 +204,7 @@ class SymbolicState:
             },
             memory_cells=memory_cells_copy,
             memory_model=forked_memory_model,
-            tensor_shapes=dict(self.tensor_shapes),
+            tensor_memory_model=forked_tensor_memory_model,
         )
 
     def add_path_condition(self, condition: z3.ExprRef) -> None:

--- a/debugger/interpreter/operations.py
+++ b/debugger/interpreter/operations.py
@@ -344,6 +344,7 @@ def operation_from_dict(op_dict: Dict[str, Any]) -> Operation:
         "uitofp",
         "truncf",
         "extf",
+        "splat",
     }
     if name in unary_ops:
         dest = op_dict.get("dest")
@@ -408,14 +409,34 @@ def operation_from_dict(op_dict: Dict[str, Any]) -> Operation:
         dest = op_dict.get("dest")
         if dest is not None:
             dest = clean_operand(dest)
-        memref = clean_operand(
-            op_dict.get("memref", op_dict.get("arg", op_dict.get("addr", "")))
+        # Handle both old (src/dst/index) and new (memref/value/indices) formats
+        # Also handle memref.store fields (addr, ref)
+        memref = op_dict.get("memref")
+        if memref is None:
+            # Try dst (old tensor.insert format)
+            memref = op_dict.get("dst")
+        if memref is None:
+            # Try addr (memref.store format)
+            memref = op_dict.get("addr")
+        value = op_dict.get("value")
+        if value is None:
+            # Try src (old tensor.insert format)
+            value = op_dict.get("src")
+        if value is None:
+            # Try ref (memref.store format)
+            value = op_dict.get("ref")
+        indices = op_dict.get("indices")
+        if indices is None:
+            indices = op_dict.get("index", [])
+
+        memref = clean_operand(memref if memref is not None else "")
+        value = clean_operand(value if value is not None else "")
+        indices = [clean_operand(idx) for idx in indices]
+
+        # Debug
+        print(
+            f"DEBUG operation_from_dict insert: op_dict keys={list(op_dict.keys())}, memref={memref}, value={value}, indices={indices}"
         )
-        indices = [
-            clean_operand(idx)
-            for idx in op_dict.get("indices", op_dict.get("index", []))
-        ]
-        value = clean_operand(op_dict.get("value", op_dict.get("ref", "")))
         return StoreOperation(
             dialect=dialect,
             name=name,

--- a/debugger/interpreter/parser.py
+++ b/debugger/interpreter/parser.py
@@ -2065,12 +2065,13 @@ class MLIRParser:
 
     def _parse_tensor_insert_op(self, op_node):
         """Parse tensor.insert operation."""
+        print(f"DEBUG _parse_tensor_insert_op called: op_node={op_node}")
         op = op_node.op
         result = {
             "op": op.__class__._opname_,
-            "src": self._ssa_use_to_string(op.src),
-            "dst": self._ssa_use_to_string(op.dst),
-            "index": [self._ssa_use_to_string(idx) for idx in op.index],
+            "memref": self._ssa_use_to_string(op.dst),  # tensor being inserted into
+            "value": self._ssa_use_to_string(op.src),  # value to insert
+            "indices": [self._ssa_use_to_string(idx) for idx in op.index],
             "type": self._type_to_string(op.type),
         }
         if op_node.result_list:

--- a/debugger/interpreter/stepper.py
+++ b/debugger/interpreter/stepper.py
@@ -477,6 +477,58 @@ class ExecutionStepper:
                 cell_summary["_memory_indices"] = indices
                 variables[cell_key] = cell_summary
 
+        # Add tensor memory entries from tensor memory model
+        tensor_entries = self.current_state.tensor_memory_model.get_all_memory_entries()
+        for tensor_name, entries in tensor_entries.items():
+            if not entries:
+                # Still show allocated tensors
+                if tensor_name in self.current_state.tensor_memory_model.shapes:
+                    shape = self.current_state.tensor_memory_model.shapes[tensor_name]
+                    dtype = self.current_state.tensor_memory_model.dtypes.get(
+                        tensor_name, "unknown"
+                    )
+                    region_summary = {
+                        "name": f"{tensor_name} (tensor)",
+                        "value": f"shape={shape}, dtype={dtype}",
+                        "type": "tensor_region",
+                        "presentationHint": "data",
+                        "_tensor_region": True,
+                        "_tensor_name": tensor_name,
+                    }
+                    variables[f"{tensor_name}_tensor"] = region_summary
+                continue
+
+            # Create a summary for the tensor region
+            shape = self.current_state.tensor_memory_model.shapes.get(tensor_name, ())
+            dtype = self.current_state.tensor_memory_model.dtypes.get(tensor_name, "unknown")
+            region_summary = {
+                "name": f"{tensor_name} (tensor)",
+                "value": f"{len(entries)} entries, shape={shape}, dtype={dtype}",
+                "type": "tensor_region",
+                "presentationHint": "data",
+                "_tensor_region": True,
+                "_tensor_name": tensor_name,
+            }
+            variables[f"{tensor_name}_tensor"] = region_summary
+
+            # Add individual entries (could be many)
+            for entry in entries:
+                indices = entry["indices"]
+                # Skip sentinel for symbolic stores
+                if indices == (-1,):
+                    continue
+
+                cell_key = f"{tensor_name}{''.join(f'[{i}]' for i in indices)}"
+                cell_summary = get_variable_summary(
+                    name=cell_key,
+                    value=entry["symbolic_expr"],
+                    value_type=dtype,
+                    concrete_value=entry["concrete_value"],
+                )
+                cell_summary["_tensor_cell"] = True
+                cell_summary["_tensor_indices"] = indices
+                variables[cell_key] = cell_summary
+
         # Add path conditions as special variable
         if self.current_state.path_condition:
             path_cond_strs = [str(pc) for pc in self.current_state.path_condition]
@@ -508,6 +560,27 @@ class ExecutionStepper:
                 "presentationHint": "data",
                 "_skip_dap": False,
                 "details": memref_counts,
+            }
+
+        # Add tensor map summary using tensor memory model
+        tensor_counts = {}
+        for tensor_name in self.current_state.tensor_memory_model.shapes:
+            entries = tensor_entries.get(tensor_name, [])
+            # Count only concrete cells (not sentinel (-1,) indices)
+            concrete_count = sum(1 for e in entries if e["indices"] != (-1,))
+            tensor_counts[tensor_name] = concrete_count
+
+        if tensor_counts:
+            tensor_summary = ", ".join(
+                f"{tensor}: {count} cells" for tensor, count in tensor_counts.items()
+            )
+            variables[""] = {
+                "name": "",
+                "value": tensor_summary,
+                "type": "tensor_map",
+                "presentationHint": "data",
+                "_skip_dap": False,
+                "details": tensor_counts,
             }
 
         # Add control flow information

--- a/debugger/tests/test_memory_ops.py
+++ b/debugger/tests/test_memory_ops.py
@@ -69,10 +69,9 @@ module {
     ret_value = state.get_value("return")
     assert ret_value is not None
     assert isinstance(ret_value.expr, z3.ExprRef)
-    # Memory should contain tensor and new_tensor
-    # Currently tensor and new_tensor are separate memory entries
-    # (simplified model)
-    assert "tensor" in state.memory or "new_tensor" in state.memory
+    # Tensors are now stored in tensor memory model, not legacy memory
+    assert "tensor" in state.tensor_memory_model.shapes
+    assert "new_tensor" in state.tensor_memory_model.shapes
 
 
 @pytest.mark.concolic


### PR DESCRIPTION
## Summary
- Add TensorMemoryModel class for immutable tensor values  
- Separate tensor and memref memory models in SymbolicState  
- Implement copy-on-write semantics for tensor.insert  
- Update all tensor operation handlers to use tensor memory model  
- Remove legacy tensor_shapes field from SymbolicState  
- Update stepper.py to show tensor memory entries  
- Fix memref.store parsing (addr/ref fields)  

## Related Issue
Fixes #2  

## Technical Details
- **TensorMemoryModel**: New class in `debugger/interpreter/memory/tensor.py` that handles immutable tensor values with copy-on-write semantics for `tensor.insert`
- **Memory Model Separation**: `SymbolicState` now has separate `memory_model` (for memrefs) and `tensor_memory_model` (for tensors)
- **Copy-on-Write**: `tensor.insert` creates new tensor copy with updated value instead of modifying in-place
- **Backward Compatibility**: Maintains compatibility with existing tests while providing proper tensor/memref semantics
- **Debugger Integration**: Updated `stepper.py` to display tensor memory entries separately from memref memory

## Testing
- All existing tests pass, including tensor operations and memory debugging
- Added proper tensor/memref separation for memory display in debugger UI
- Fixed parsing of `memref.store` operations that use `addr`/`ref` fields