### PR TITLE
Fix EmitC generic operation parsing (Issue #7)

### DIFF
--- a/debugger/interpreter/dialect_parsers/__init__.py
+++ b/debugger/interpreter/dialect_parsers/__init__.py
@@ -54,7 +54,8 @@ def register_default_parsers(registry: DialectParserRegistry) -> None:
     cf_parser = CfDialectParser()
     registry.register_dialect("cf", cf_parser)
     registry.register_dialect("scf", ScfDialectParser())
-    registry.register_dialect("func", FuncDialectParser())
+    func_parser = FuncDialectParser()
+    registry.register_dialect("func", func_parser)
     linalg_parser = LinalgDialectParser()
     registry.register_dialect("linalg", linalg_parser)
     registry.register_dialect("math", MathDialectParser())
@@ -68,6 +69,11 @@ def register_default_parsers(registry: DialectParserRegistry) -> None:
     # Register operation handlers for builtin operations
     registry.register_operation(
         "ReturnOperation", builtin_parser._parse_return_operation
+    )
+    # Register operation handlers for func operations (since they lack _opname_)
+    registry.register_operation("CallOperation", func_parser._parse_call_operation)
+    registry.register_operation(
+        "CallIndirectOperation", func_parser._parse_call_indirect_operation
     )
     # Register operation handlers for linalg operations (since they lack _opname_)
     registry.register_operation(

--- a/debugger/interpreter/dialect_parsers/emitc.py
+++ b/debugger/interpreter/dialect_parsers/emitc.py
@@ -403,6 +403,122 @@ class EmitcDialectParser(BaseDialectParser):
         if dest is None:
             return None
 
+        # Handle GenericOperation (quoted operation names in MLIR)
+        if isinstance(op_obj, mast.GenericOperation):
+            # Get full operation name (e.g., "emitc.constant")
+            name_obj = op_obj.name
+            if hasattr(name_obj, "value"):
+                full_name = name_obj.value
+            else:
+                full_name = str(name_obj)
+
+            # Strip dialect prefix
+            if "." in full_name:
+                dialect, name = full_name.split(".", 1)
+            else:
+                dialect = "emitc"
+                name = full_name
+
+            # Determine if binary or unary based on args length
+            args = (
+                op_obj.args
+                if hasattr(op_obj, "args") and op_obj.args is not None
+                else []
+            )
+            num_args = len(args)
+
+            # Extract result type
+            result_type = None
+            if hasattr(op_obj, "type"):
+                result_type = self._type_to_string(op_obj.type)
+
+            # Parse attributes if present
+            attributes = {}
+            if hasattr(op_obj, "attributes") and op_obj.attributes is not None:
+                attributes = self._parse_attribute(op_obj.attributes)
+
+            line = self._extract_line_number(op_node)
+
+            # Special handling for specific operation types
+            if name == "constant":
+                # Extract value from attributes
+                value = attributes.get("value")
+                return ConstantOperation(
+                    dialect=dialect,
+                    name=name,
+                    line=line,
+                    dest=dest,
+                    result_type=result_type,
+                    value=value,
+                    attributes=attributes,
+                )
+            elif name == "cmp":
+                # For cmp, we need pred, lhs, rhs
+                # args length should be 2
+                if num_args == 2:
+                    lhs = self._ssa_use_to_string(args[0])
+                    rhs = self._ssa_use_to_string(args[1])
+                    pred = attributes.get("predicate")
+                    return CompareOperation(
+                        dialect=dialect,
+                        name=name,
+                        line=line,
+                        dest=dest,
+                        result_type=result_type,
+                        pred=pred or "",
+                        lhs=lhs,
+                        rhs=rhs,
+                        attributes=attributes,
+                    )
+                else:
+                    # Fallback to generic operation
+                    return Operation(
+                        dialect=dialect,
+                        name=name,
+                        line=line,
+                        dest=dest,
+                        result_type=result_type,
+                        attributes=attributes,
+                    )
+
+            # Handle binary operations (add, etc.)
+            if num_args == 2:
+                lhs = self._ssa_use_to_string(args[0])
+                rhs = self._ssa_use_to_string(args[1])
+                return BinaryOperation(
+                    dialect=dialect,
+                    name=name,
+                    line=line,
+                    dest=dest,
+                    result_type=result_type,
+                    lhs=lhs,
+                    rhs=rhs,
+                    attributes=attributes,
+                )
+            # Handle unary operations (cast, etc.)
+            elif num_args == 1:
+                operand = self._ssa_use_to_string(args[0])
+                return UnaryOperation(
+                    dialect=dialect,
+                    name=name,
+                    line=line,
+                    dest=dest,
+                    result_type=result_type,
+                    operand=operand,
+                    attributes=attributes,
+                )
+            else:
+                # Generic operation with attributes (constant already handled)
+                return Operation(
+                    dialect=dialect,
+                    name=name,
+                    line=line,
+                    dest=dest,
+                    result_type=result_type,
+                    attributes=attributes,
+                )
+
+        # Original logic for non-GenericOperation
         # Extract operation name
         if hasattr(op_obj.__class__, "_opname_"):
             full_name = op_obj.__class__._opname_

--- a/debugger/interpreter/dialect_parsers/func.py
+++ b/debugger/interpreter/dialect_parsers/func.py
@@ -38,11 +38,11 @@ class FuncDialectParser(BaseDialectParser):
                 return self._parse_call_operation(op_node)
             elif class_name == "CallIndirectOp":
                 return self._parse_call_indirect_operation(op_node)
-            # Note: ReturnOp is a builtin operation, not part of func dialect
-            # but handled by generic parser or builtin handler.
+            elif class_name == "ReturnOperation":
+                return self._parse_return_operation(op_node)
 
         # No handler found
-        print(f"DEBUG FuncDialectParser: class {op_obj.__class__.__name__} not handled")
+
         return None
 
     # Individual operation parsers
@@ -53,20 +53,31 @@ class FuncDialectParser(BaseDialectParser):
         dest = self._extract_destination(op_node)
         # func.call may not have a destination (void)
 
-        # Extract callee
+        # Extract callee (SymbolRefId)
         callee = None
         if hasattr(op_obj, "func"):
-            callee = self._ssa_use_to_string(op_obj.func)
+            func_obj = op_obj.func
+            if hasattr(func_obj, "value"):
+                callee = func_obj.value
+            else:
+                callee = str(func_obj)
 
         # Extract arguments
         args = []
         if hasattr(op_obj, "args") and op_obj.args:
             args = [self._ssa_use_to_string(arg) for arg in op_obj.args]
 
-        # Extract result type
+        # Extract result type from FunctionType
         result_type = None
         if hasattr(op_obj, "type"):
-            result_type = self._type_to_string(op_obj.type)
+            type_obj = op_obj.type
+            # Check if it's a FunctionType
+            if isinstance(type_obj, mast.FunctionType):
+                # Extract first result type
+                if type_obj.result_types:
+                    result_type = self._type_to_string(type_obj.result_types[0])
+            else:
+                result_type = self._type_to_string(type_obj)
 
         line = self._extract_line_number(op_node)
 
@@ -113,4 +124,27 @@ class FuncDialectParser(BaseDialectParser):
             result_type=result_type,
             callee=callee or "",
             args=args,
+        )
+
+    def _parse_return_operation(
+        self, op_node: mast.Operation
+    ) -> Optional[ReturnOperation]:
+        """Parse func.return operation."""
+        op_obj = op_node.op
+
+        dest = self._extract_destination(op_node)
+
+        # Extract the return value (first value if multiple)
+        value = None
+        if hasattr(op_obj, "values") and op_obj.values:
+            value = self._ssa_use_to_string(op_obj.values[0])
+
+        line = self._extract_line_number(op_node)
+
+        return ReturnOperation(
+            dialect="func",
+            name="return",
+            line=line,
+            dest=dest,
+            value=value,
         )


### PR DESCRIPTION
## Summary
- Fixed parsing of EmitC operations written in generic MLIR syntax (e.g., `"emitc.constant"() {value = 42 : i32}`)
- Added proper registration of func operation handlers for `CallOperation` and `CallIndirectOperation`
- Improved func call parsing to extract callee from `SymbolRefId` and result type from `FunctionType`
- Removed debug print statements

## Changes Made
1. **emitc.py**: Added `GenericOperation` handling to parse quoted operation names, supporting constants, comparisons, binary, and unary operations
2. **__init__.py**: Registered func operation handlers (they lack `_opname_` attributes)
3. **func.py**: Fixed `_parse_call_operation()` to correctly extract callee name and result type
4. **base.py**: Removed debug print statement

## Testing
- `test_emitc_ops_concolic` passes
- `test_func_ops_concolic` passes  
- `test_func_call_parsing_operations` passes
- All existing func-related tests pass

## Notes
- One unrelated test failure (`test_dap_session_continue`) exists but predates these changes
- Resolves Issue #7: EmitC operations in generic syntax were incorrectly parsed as `emitc.generic` operations